### PR TITLE
Clarifies exercise window for Carta

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Name | Exercise Window | Additional details
 [Braid](https://braidhq.com) | 5 years
 [Buffer](https://buffer.com) | [10 years](https://open.buffer.com/explaining-equity/)
 [BuildZoom](https://www.buildzoom.com/) | [10 years](https://triplebyte.com/startup/buildzoom)
-[Carta](https://carta.com) | [1 year for each year of employment](https://carta.com/blog/pte-vesting/)
+[Carta](https://carta.com) | [1 year for each year of vesting](https://carta.com/blog/pte-vesting/)
 [Checkr](https://checkr.com) | 10 years | After 2 years of employment
 [Cinder](https://cindercooks.com/) | [10 years](https://triplebyte.com/startup/cinder)
 [Circle Medical](https://www.circlemedical.com/) | [5 years](https://triplebyte.com/startup/circle-medical)


### PR DESCRIPTION
Clarifies that Carta's exercise window does not match the employment tenure, but rather the amount vesting period elapsed for each individual grant.