### PR TITLE
adds PostHog to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Name | Exercise Window | Additional details
 [Persista](http://persista.com) | 1 year
 [Pex](https://pex.com) | 10 years
 [PhotoRoom](https://www.photoroom.com) | 10 years | After 2 years of employment
+[PostHog](https://posthog.com/) | 10 years | Read about it in [the open source company handbook](https://posthog.com/handbook/people/share-options)
 [Postscript](https://postscript.io) | 8 years | After 2 years of employment
 [Puppet](https://puppet.com) | 1 year | After 2 years of employment
 [Quora](https://quora.com) | [10 years](https://twitter.com/adamdangelo/status/623734971090518017)


### PR DESCRIPTION
quoting our handbook "The industry standard is to only give you 90 days to exercise after leaving, which we think is bogus."

great list 🙌